### PR TITLE
Retrofit existing code with unit tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,11 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>
+            <exclude>
+                <directory suffix=".php">src/DependencyInjection</directory>
+                <file>src/PersonalizedSearchBundle.php</file>
+                <directory suffix=".php">src/tests</directory>
+            </exclude>
         </whitelist>
     </filter>
 

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -3,10 +3,6 @@
 
 namespace Pimcore\Bundle\PersonalizedSearchBundle\Adapter;
 
-class AbstractAdapter implements AdapterInterface
+abstract class AbstractAdapter implements AdapterInterface
 {
-    public function addPersonalization(array $query, float $weight = 1, string $boostMode = "multiply"): array
-    {
-        // TODO: Implement addPersonalization() method.
-    }
 }

--- a/src/Adapter/AccessoryAdapter.php
+++ b/src/Adapter/AccessoryAdapter.php
@@ -14,7 +14,7 @@ class AccessoryAdapter extends AbstractAdapter
      * @param string $boostMode
      * @return array
      */
-    public function addPersonalization(array $query, float $weight = 1, string $boostMode = "multiply"): array
+    public function addPersonalization(array $query, float $weight = 1.0, string $boostMode = "multiply"): array
     {
         $functions = [
             [

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -5,5 +5,5 @@ namespace Pimcore\Bundle\PersonalizedSearchBundle\Adapter;
 
 interface AdapterInterface
 {
-    public function addPersonalization(array $query, float $weight = 1, string $boostMode = "multiply"): array;
+    public function addPersonalization(array $query, float $weight = 1.0, string $boostMode = "multiply"): array;
 }

--- a/src/Adapter/PurchaseHistoryAdapter.php
+++ b/src/Adapter/PurchaseHistoryAdapter.php
@@ -34,7 +34,7 @@ class PurchaseHistoryAdapter extends AbstractAdapter
      * @param string $boostMode
      * @return array
      */
-    public function addPersonalization(array $query, float $weight = 1, string $boostMode = "multiply"): array
+    public function addPersonalization(array $query, float $weight = 1.0, string $boostMode = "multiply"): array
     {
         $customerId = $this->customerIdProvider->getCustomerId();
         $response = $this->orderIndex->fetchSegments($customerId);

--- a/src/Adapter/PurchaseHistoryAdapter.php
+++ b/src/Adapter/PurchaseHistoryAdapter.php
@@ -3,8 +3,8 @@
 
 namespace Pimcore\Bundle\PersonalizedSearchBundle\Adapter;
 
+use Pimcore\Bundle\PersonalizedSearchBundle\Customer\PurchaseHistoryAdapterCustomerIdProvider;
 use Pimcore\Bundle\PersonalizedSearchBundle\IndexAccessProvider\OrderIndexAccessProvider;
-use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
 
 class PurchaseHistoryAdapter extends AbstractAdapter
 {
@@ -15,9 +15,15 @@ class PurchaseHistoryAdapter extends AbstractAdapter
      */
     private $orderIndex;
 
-    public function __construct(OrderIndexAccessProvider $orderIndex)
+    /**
+     * @var PurchaseHistoryAdapterCustomerIdProvider
+     */
+    private $customerIdProvider;
+
+    public function __construct(OrderIndexAccessProvider $orderIndex, PurchaseHistoryAdapterCustomerIdProvider $purchaseHistoryAdapterCustomerIdProvider)
     {
         $this->orderIndex = $orderIndex;
+        $this->customerIdProvider = $purchaseHistoryAdapterCustomerIdProvider;
     }
 
     /**
@@ -30,7 +36,7 @@ class PurchaseHistoryAdapter extends AbstractAdapter
      */
     public function addPersonalization(array $query, float $weight = 1, string $boostMode = "multiply"): array
     {
-        $customerId = Factory::getInstance()->getEnvironment()->getCurrentUserId();
+        $customerId = $this->customerIdProvider->getCustomerId();
         $response = $this->orderIndex->fetchSegments($customerId);
 
         $functions = [];

--- a/src/Adapter/SegmentAdapter.php
+++ b/src/Adapter/SegmentAdapter.php
@@ -35,7 +35,7 @@ class SegmentAdapter extends AbstractAdapter
      * @param string $boostMode
      * @return array
      */
-    public function addPersonalization(array $query, float $weight = 1, string $boostMode = "multiply"): array
+    public function addPersonalization(array $query, float $weight = 1.0, string $boostMode = "multiply"): array
     {
         $functions = [];
 

--- a/src/Customer/PurchaseHistoryAdapterCustomerIdProvider.php
+++ b/src/Customer/PurchaseHistoryAdapterCustomerIdProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Pimcore\Bundle\PersonalizedSearchBundle\Customer;
+
+
+interface PurchaseHistoryAdapterCustomerIdProvider
+{
+    public function getCustomerId(): int;
+}

--- a/src/Decorator/AbstractDecorator.php
+++ b/src/Decorator/AbstractDecorator.php
@@ -20,7 +20,7 @@ abstract class AbstractDecorator implements AdapterInterface
         return $this;
     }
 
-    public function addPersonalization(array $query, float $weight = 1, string $boostMode = "multiply"): array
+    public function addPersonalization(array $query, float $weight = 1.0, string $boostMode = "multiply"): array
     {
         foreach ($this->adapters as $adapter) {
             $query = $this->invokeAdapter($adapter, $query);

--- a/src/ExtractTransformLoad/CustomerInfo.php
+++ b/src/ExtractTransformLoad/CustomerInfo.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad;
+
+
+class CustomerInfo
+{
+    public $customerId;
+    public $segments;
+
+    public function __construct($customerId)
+    {
+        $this->customerId = $customerId;
+        $this->segments = [];
+    }
+}

--- a/src/ExtractTransformLoad/PurchaseHistoryProvider.php
+++ b/src/ExtractTransformLoad/PurchaseHistoryProvider.php
@@ -74,25 +74,3 @@ class PurchaseHistoryProvider implements PurchaseHistoryInterface
         return $customerInfo;
     }
 }
-
-class CustomerInfo {
-    public $customerId;
-    public $segments;
-
-    public function __construct($customerId) {
-        $this->customerId = $customerId;
-        $this->segments = [];
-    }
-};
-
-class SegmentInfo {
-
-    public $segmentId;
-    public $segmentCount;
-
-    public function __construct($segmentId, $segmentCount)
-    {
-        $this->segmentId = $segmentId;
-        $this->segmentCount = $segmentCount;
-    }
-}

--- a/src/ExtractTransformLoad/SegmentInfo.php
+++ b/src/ExtractTransformLoad/SegmentInfo.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad;
+
+
+class SegmentInfo
+{
+    public $segmentId;
+    public $segmentCount;
+
+    public function __construct($segmentId, $segmentCount)
+    {
+        $this->segmentId = $segmentId;
+        $this->segmentCount = $segmentCount;
+    }
+}

--- a/src/IndexAccessProvider/OrderIndexAccessProvider.php
+++ b/src/IndexAccessProvider/OrderIndexAccessProvider.php
@@ -20,7 +20,9 @@ class OrderIndexAccessProvider implements IndexAccessProviderInterface
 
     public function __construct()
     {
-        $this->esClient = ClientBuilder::create()->build();
+        if (class_exists('Elasticsearch\\ClientBuilder')) {
+            $this->esClient = ClientBuilder::create()->build();
+        }
     }
 
     /**

--- a/tests/PersonalizedSearchBundle/Adapter/PurchaseHistoryAdapterTest.php
+++ b/tests/PersonalizedSearchBundle/Adapter/PurchaseHistoryAdapterTest.php
@@ -1,11 +1,14 @@
 <?php
 
+namespace Pimcore\Bundle\PersonalizedSearchBundle\Tests\Adapter;
+
 use PHPUnit\Framework\TestCase;
 use Pimcore\Bundle\PersonalizedSearchBundle\Adapter\PurchaseHistoryAdapter;
 use Pimcore\Bundle\PersonalizedSearchBundle\Customer\PurchaseHistoryAdapterCustomerIdProvider;
 use Pimcore\Bundle\PersonalizedSearchBundle\IndexAccessProvider\OrderIndexAccessProvider;
 
-class PurchaseHistoryAdapterTest extends TestCase {
+class PurchaseHistoryAdapterTest extends TestCase
+{
     public function testNoUserLoggedIn() {
         $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
         $expectedPurchaseHistoryBoostedQueryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );

--- a/tests/PersonalizedSearchBundle/Adapter/PurchaseHistoryAdapterTest.php
+++ b/tests/PersonalizedSearchBundle/Adapter/PurchaseHistoryAdapterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Pimcore\Bundle\PersonalizedSearchBundle\Adapter\PurchaseHistoryAdapter;
+use Pimcore\Bundle\PersonalizedSearchBundle\Customer\PurchaseHistoryAdapterCustomerIdProvider;
+use Pimcore\Bundle\PersonalizedSearchBundle\IndexAccessProvider\OrderIndexAccessProvider;
+
+class PurchaseHistoryAdapterTest extends TestCase {
+    public function testNoUserLoggedIn() {
+        $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
+        $expectedPurchaseHistoryBoostedQueryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
+
+        $orderIndexResponse = array ( );
+        $customerId = -1;
+        $purchaseHistoryAdapter = $this->constructPurchaseHistoryAdapter($customerId, $orderIndexResponse);
+        $actualPurchaseHistoryBoostedQueryRed = $purchaseHistoryAdapter->addPersonalization($queryRed);
+
+        self::assertEquals($expectedPurchaseHistoryBoostedQueryRed, $actualPurchaseHistoryBoostedQueryRed);
+    }
+
+    public function testCorvetteFanLoggedIn() {
+        $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
+        $expectedPurchaseHistoryBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 983, ), ), 'weight' => 6.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 963, ), ), 'weight' => 6.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 982, ), ), 'weight' => 6.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 971, ), ), 'weight' => 6.0, ), 4 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 970, ), ), 'weight' => 6.0, ), ), 'boost_mode' => 'multiply', ), );
+
+        $orderIndexResponse = array ( 0 => array ( 'segmentId' => 983, 'segmentCount' => 1, ), 1 => array ( 'segmentId' => 963, 'segmentCount' => 1, ), 2 => array ( 'segmentId' => 982, 'segmentCount' => 1, ), 3 => array ( 'segmentId' => 971, 'segmentCount' => 1, ), 4 => array ( 'segmentId' => 970, 'segmentCount' => 1, ), );
+        $customerId = 1021;
+        $purchaseHistoryAdapter = $this->constructPurchaseHistoryAdapter($customerId, $orderIndexResponse);
+        $actualPurchaseHistoryBoostedQueryRed = $purchaseHistoryAdapter->addPersonalization($queryRed);
+
+        self::assertEquals($expectedPurchaseHistoryBoostedQueryRed, $actualPurchaseHistoryBoostedQueryRed);
+    }
+
+    public function testCorvetteFanLoggedInDifferentWeight() {
+        $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
+        $expectedPurchaseHistoryBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 983, ), ), 'weight' => 72.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 963, ), ), 'weight' => 72.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 982, ), ), 'weight' => 72.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 971, ), ), 'weight' => 72.0, ), 4 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 970, ), ), 'weight' => 72.0, ), ), 'boost_mode' => 'multiply', ), );
+
+        $orderIndexResponse = array ( 0 => array ( 'segmentId' => 983, 'segmentCount' => 1, ), 1 => array ( 'segmentId' => 963, 'segmentCount' => 1, ), 2 => array ( 'segmentId' => 982, 'segmentCount' => 1, ), 3 => array ( 'segmentId' => 971, 'segmentCount' => 1, ), 4 => array ( 'segmentId' => 970, 'segmentCount' => 1, ), );
+        $customerId = 1021;
+        $purchaseHistoryAdapter = $this->constructPurchaseHistoryAdapter($customerId, $orderIndexResponse);
+        $actualPurchaseHistoryBoostedQueryRed = $purchaseHistoryAdapter->addPersonalization($queryRed, 12);
+
+        self::assertEquals($expectedPurchaseHistoryBoostedQueryRed, $actualPurchaseHistoryBoostedQueryRed);
+    }
+
+    private function constructPurchaseHistoryAdapter(int $customerId, array $orderIndexResponse) : PurchaseHistoryAdapter {
+        $orderIndex = $this->getMockBuilder(OrderIndexAccessProvider::class)
+            ->setMethods(['fetchSegments'])
+            ->getMock();
+        $orderIndex->method('fetchSegments')
+            ->willReturn($orderIndexResponse);
+
+        $customerIdProvider = $this->getMockBuilder(PurchaseHistoryAdapterCustomerIdProvider::class)
+            ->setMethods(['getCustomerId'])
+            ->getMock();
+        $customerIdProvider->method('getCustomerId')
+            ->willReturn($customerId);
+
+        return new PurchaseHistoryAdapter($orderIndex, $customerIdProvider);
+    }
+}

--- a/tests/PersonalizedSearchBundle/Decorator/EqualWeightDecoratorTest.php
+++ b/tests/PersonalizedSearchBundle/Decorator/EqualWeightDecoratorTest.php
@@ -13,7 +13,8 @@ use Pimcore\Targeting\VisitorInfoStorage;
 
 class EqualWeightDecoratorTest extends TestCase
 {
-    public function testSegmentBasedAdapterOnly() {
+    public function testSegmentBasedAdapterOnly()
+    {
         $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
         $expectedSegmentBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 860, ), ), 'weight' => 1.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 966, ), ), 'weight' => 7.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 967, ), ), 'weight' => 7.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 968, ), ), 'weight' => 7.0, ), ), 'boost_mode' => 'multiply', ), );
 
@@ -25,7 +26,8 @@ class EqualWeightDecoratorTest extends TestCase
         self::assertEquals($expectedSegmentBoostedQueryRed, $actualSegmentAdapterBoostedQueryRed);
     }
 
-    public function testPurchaseHistoryAdapterOnly() {
+    public function testPurchaseHistoryAdapterOnly()
+    {
         $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
         $expectedPurchaseHistoryBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 983, ), ), 'weight' => 6.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 963, ), ), 'weight' => 6.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 982, ), ), 'weight' => 6.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 971, ), ), 'weight' => 6.0, ), 4 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 970, ), ), 'weight' => 6.0, ), ), 'boost_mode' => 'multiply', ), );
 
@@ -39,7 +41,8 @@ class EqualWeightDecoratorTest extends TestCase
         self::assertEquals($expectedPurchaseHistoryBoostedQueryRed, $actualPurchaseHistoryBoostedQueryRed);
     }
 
-    public function testSegmentAdapterFirstPurchaseHistoryAdapterSecond() {
+    public function testSegmentAdapterFirstPurchaseHistoryAdapterSecond()
+    {
         $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
         $expectedBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 860, ), ), 'weight' => 1.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 966, ), ), 'weight' => 7.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 967, ), ), 'weight' => 7.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 968, ), ), 'weight' => 7.0, ), ), 'boost_mode' => 'multiply', ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 983, ), ), 'weight' => 6.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 963, ), ), 'weight' => 6.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 982, ), ), 'weight' => 6.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 971, ), ), 'weight' => 6.0, ), 4 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 970, ), ), 'weight' => 6.0, ), ), 'boost_mode' => 'multiply', ), );
 
@@ -57,7 +60,8 @@ class EqualWeightDecoratorTest extends TestCase
         self::assertEquals($expectedBoostedQueryRed, $actualBoostedQueryRed);
     }
 
-    public function testPurchaseHistoryAdapterFirstSegmentAdapterSecond() {
+    public function testPurchaseHistoryAdapterFirstSegmentAdapterSecond()
+    {
         $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
         $expectedBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 983, ), ), 'weight' => 6.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 963, ), ), 'weight' => 6.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 982, ), ), 'weight' => 6.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 971, ), ), 'weight' => 6.0, ), 4 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 970, ), ), 'weight' => 6.0, ), ), 'boost_mode' => 'multiply', ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 860, ), ), 'weight' => 1.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 966, ), ), 'weight' => 7.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 967, ), ), 'weight' => 7.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 968, ), ), 'weight' => 7.0, ), ), 'boost_mode' => 'multiply', ), );
 
@@ -75,7 +79,8 @@ class EqualWeightDecoratorTest extends TestCase
         self::assertEquals($expectedBoostedQueryRed, $actualBoostedQueryRed);
     }
 
-    private function constructSegmentAdapter() : SegmentAdapter {
+    private function constructSegmentAdapter() : SegmentAdapter
+    {
         $visitorInfoStorage = $this
             ->getMockBuilder(VisitorInfoStorage::class)
             ->setMethods(['getVisitorInfo'])
@@ -93,7 +98,8 @@ class EqualWeightDecoratorTest extends TestCase
         return new SegmentAdapter($visitorInfoStorage, $segmentTracker);
     }
 
-    private function constructPurchaseHistoryAdapter(int $customerId, array $orderIndexResponse) : PurchaseHistoryAdapter {
+    private function constructPurchaseHistoryAdapter(int $customerId, array $orderIndexResponse) : PurchaseHistoryAdapter
+    {
         $orderIndex = $this->getMockBuilder(OrderIndexAccessProvider::class)
             ->setMethods(['fetchSegments'])
             ->getMock();

--- a/tests/PersonalizedSearchBundle/Decorator/EqualWeightDecoratorTest.php
+++ b/tests/PersonalizedSearchBundle/Decorator/EqualWeightDecoratorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use CustomerManagementFrameworkBundle\Targeting\SegmentTracker;
+use PHPUnit\Framework\TestCase;
+use Pimcore\Bundle\PersonalizedSearchBundle\Adapter\PurchaseHistoryAdapter;
+use Pimcore\Bundle\PersonalizedSearchBundle\Adapter\SegmentAdapter;
+use Pimcore\Bundle\PersonalizedSearchBundle\Customer\PurchaseHistoryAdapterCustomerIdProvider;
+use Pimcore\Bundle\PersonalizedSearchBundle\Decorator\EqualWeightDecorator;
+use Pimcore\Bundle\PersonalizedSearchBundle\IndexAccessProvider\OrderIndexAccessProvider;
+use Pimcore\Targeting\VisitorInfoStorage;
+
+class EqualWeightDecoratorTest extends TestCase {
+    public function testSegmentBasedAdapterOnly() {
+        $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
+        $expectedSegmentBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 860, ), ), 'weight' => 1.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 966, ), ), 'weight' => 7.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 967, ), ), 'weight' => 7.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 968, ), ), 'weight' => 7.0, ), ), 'boost_mode' => 'multiply', ), );
+
+        $equalWeightDecorator = new EqualWeightDecorator();
+        $segmentAdapter = $this->constructSegmentAdapter();
+        $equalWeightDecorator->addAdapter($segmentAdapter);
+
+        $actualSegmentAdapterBoostedQueryRed = $equalWeightDecorator->addPersonalization($queryRed);
+        self::assertEquals($expectedSegmentBoostedQueryRed, $actualSegmentAdapterBoostedQueryRed);
+    }
+
+    public function testPurchaseHistoryAdapterOnly() {
+        $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
+        $expectedPurchaseHistoryBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 983, ), ), 'weight' => 6.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 963, ), ), 'weight' => 6.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 982, ), ), 'weight' => 6.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 971, ), ), 'weight' => 6.0, ), 4 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 970, ), ), 'weight' => 6.0, ), ), 'boost_mode' => 'multiply', ), );
+
+        $equalWeightDecorator = new EqualWeightDecorator();
+        $orderIndexResponse = array ( 0 => array ( 'segmentId' => 983, 'segmentCount' => 1, ), 1 => array ( 'segmentId' => 963, 'segmentCount' => 1, ), 2 => array ( 'segmentId' => 982, 'segmentCount' => 1, ), 3 => array ( 'segmentId' => 971, 'segmentCount' => 1, ), 4 => array ( 'segmentId' => 970, 'segmentCount' => 1, ), );
+        $customerId = 1021;
+        $purchaseHistoryAdapter = $this->constructPurchaseHistoryAdapter($customerId, $orderIndexResponse);
+        $equalWeightDecorator->addAdapter($purchaseHistoryAdapter);
+
+        $actualPurchaseHistoryBoostedQueryRed = $equalWeightDecorator->addPersonalization($queryRed);
+        self::assertEquals($expectedPurchaseHistoryBoostedQueryRed, $actualPurchaseHistoryBoostedQueryRed);
+    }
+
+    public function testSegmentAdapterFirstPurchaseHistoryAdapterSecond() {
+        $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
+        $expectedBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 860, ), ), 'weight' => 1.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 966, ), ), 'weight' => 7.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 967, ), ), 'weight' => 7.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 968, ), ), 'weight' => 7.0, ), ), 'boost_mode' => 'multiply', ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 983, ), ), 'weight' => 6.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 963, ), ), 'weight' => 6.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 982, ), ), 'weight' => 6.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 971, ), ), 'weight' => 6.0, ), 4 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 970, ), ), 'weight' => 6.0, ), ), 'boost_mode' => 'multiply', ), );
+
+        $equalWeightDecorator = new EqualWeightDecorator();
+
+        $segmentAdapter = $this->constructSegmentAdapter();
+        $equalWeightDecorator->addAdapter($segmentAdapter);
+
+        $orderIndexResponse = array ( 0 => array ( 'segmentId' => 983, 'segmentCount' => 1, ), 1 => array ( 'segmentId' => 963, 'segmentCount' => 1, ), 2 => array ( 'segmentId' => 982, 'segmentCount' => 1, ), 3 => array ( 'segmentId' => 971, 'segmentCount' => 1, ), 4 => array ( 'segmentId' => 970, 'segmentCount' => 1, ), );
+        $customerId = 1021;
+        $purchaseHistoryAdapter = $this->constructPurchaseHistoryAdapter($customerId, $orderIndexResponse);
+        $equalWeightDecorator->addAdapter($purchaseHistoryAdapter);
+
+        $actualBoostedQueryRed = $equalWeightDecorator->addPersonalization($queryRed);
+        self::assertEquals($expectedBoostedQueryRed, $actualBoostedQueryRed);
+    }
+
+    public function testPurchaseHistoryAdapterFirstSegmentAdapterSecond() {
+        $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
+        $expectedBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 983, ), ), 'weight' => 6.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 963, ), ), 'weight' => 6.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 982, ), ), 'weight' => 6.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 971, ), ), 'weight' => 6.0, ), 4 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 970, ), ), 'weight' => 6.0, ), ), 'boost_mode' => 'multiply', ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 860, ), ), 'weight' => 1.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 966, ), ), 'weight' => 7.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 967, ), ), 'weight' => 7.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 968, ), ), 'weight' => 7.0, ), ), 'boost_mode' => 'multiply', ), );
+
+        $equalWeightDecorator = new EqualWeightDecorator();
+
+        $orderIndexResponse = array ( 0 => array ( 'segmentId' => 983, 'segmentCount' => 1, ), 1 => array ( 'segmentId' => 963, 'segmentCount' => 1, ), 2 => array ( 'segmentId' => 982, 'segmentCount' => 1, ), 3 => array ( 'segmentId' => 971, 'segmentCount' => 1, ), 4 => array ( 'segmentId' => 970, 'segmentCount' => 1, ), );
+        $customerId = 1021;
+        $purchaseHistoryAdapter = $this->constructPurchaseHistoryAdapter($customerId, $orderIndexResponse);
+        $equalWeightDecorator->addAdapter($purchaseHistoryAdapter);
+
+        $segmentAdapter = $this->constructSegmentAdapter();
+        $equalWeightDecorator->addAdapter($segmentAdapter);
+
+        $actualBoostedQueryRed = $equalWeightDecorator->addPersonalization($queryRed);
+        self::assertEquals($expectedBoostedQueryRed, $actualBoostedQueryRed);
+    }
+
+    private function constructSegmentAdapter() : SegmentAdapter {
+        $visitorInfoStorage = $this
+            ->getMockBuilder(VisitorInfoStorage::class)
+            ->setMethods(['getVisitorInfo'])
+            ->getMock();
+        $visitorInfoStorage->method('getVisitorInfo')
+            ->willReturn(null);
+
+        $segmentTracker = $this
+            ->getMockBuilder(SegmentTracker::class)
+            ->setMethods(['getAssignments'])
+            ->getMock();
+        $segmentTracker->method('getAssignments')
+            ->willReturn(array ( 860 => 1, 966 => 7, 967 => 7, 968 => 7, ));
+
+        return new SegmentAdapter($visitorInfoStorage, $segmentTracker);
+    }
+
+    private function constructPurchaseHistoryAdapter(int $customerId, array $orderIndexResponse) : PurchaseHistoryAdapter {
+        $orderIndex = $this->getMockBuilder(OrderIndexAccessProvider::class)
+            ->setMethods(['fetchSegments'])
+            ->getMock();
+        $orderIndex->method('fetchSegments')
+            ->willReturn($orderIndexResponse);
+
+        $customerIdProvider = $this->getMockBuilder(PurchaseHistoryAdapterCustomerIdProvider::class)
+            ->setMethods(['getCustomerId'])
+            ->getMock();
+        $customerIdProvider->method('getCustomerId')
+            ->willReturn($customerId);
+
+        return new PurchaseHistoryAdapter($orderIndex, $customerIdProvider);
+    }
+}

--- a/tests/PersonalizedSearchBundle/Decorator/EqualWeightDecoratorTest.php
+++ b/tests/PersonalizedSearchBundle/Decorator/EqualWeightDecoratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Pimcore\Bundle\PersonalizedSearchBundle\Tests\Decorator;
+
 use CustomerManagementFrameworkBundle\Targeting\SegmentTracker;
 use PHPUnit\Framework\TestCase;
 use Pimcore\Bundle\PersonalizedSearchBundle\Adapter\PurchaseHistoryAdapter;
@@ -9,7 +11,8 @@ use Pimcore\Bundle\PersonalizedSearchBundle\Decorator\EqualWeightDecorator;
 use Pimcore\Bundle\PersonalizedSearchBundle\IndexAccessProvider\OrderIndexAccessProvider;
 use Pimcore\Targeting\VisitorInfoStorage;
 
-class EqualWeightDecoratorTest extends TestCase {
+class EqualWeightDecoratorTest extends TestCase
+{
     public function testSegmentBasedAdapterOnly() {
         $queryRed = array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), );
         $expectedSegmentBoostedQueryRed = array ( 'function_score' => array ( 'query' => array ( 'multi_match' => array ( 'query' => 'red', 'type' => 'cross_fields', 'operator' => 'and', 'fields' => array ( 0 => 'attributes.name^4', 1 => 'attributes.name.analyzed', 2 => 'attributes.name.analyzed_ngram', 3 => 'attributes.manufacturer_name^3', 4 => 'attributes.manufacturer_name.analyzed', 5 => 'attributes.manufacturer_name.analyzed_ngram', 6 => 'attributes.color', 7 => 'attributes.carClass', ), ), ), 'functions' => array ( 0 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 860, ), ), 'weight' => 1.0, ), 1 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 966, ), ), 'weight' => 7.0, ), 2 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 967, ), ), 'weight' => 7.0, ), 3 => array ( 'filter' => array ( 'match' => array ( 'relations.segments' => 968, ), ), 'weight' => 7.0, ), ), 'boost_mode' => 'multiply', ), );

--- a/tests/PersonalizedSearchBundle/ExtractTransformLoad/PurchaseHistoryProviderTest.php
+++ b/tests/PersonalizedSearchBundle/ExtractTransformLoad/PurchaseHistoryProviderTest.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace PersonalizedSearchBundle\tests\PersonalizedSearchBundle\ExtractTransformLoad;
+
+
+class PurchaseHistoryProviderTest
+{
+
+}

--- a/tests/PersonalizedSearchBundle/ExtractTransformLoad/PurchaseHistoryProviderTest.php
+++ b/tests/PersonalizedSearchBundle/ExtractTransformLoad/PurchaseHistoryProviderTest.php
@@ -1,10 +1,11 @@
 <?php
 
 
-namespace PersonalizedSearchBundle\tests\PersonalizedSearchBundle\ExtractTransformLoad;
+namespace Pimcore\Bundle\PersonalizedSearchBundle\Tests\ExtractTransformLoad;
 
+use PHPUnit\Framework\TestCase;
 
-class PurchaseHistoryProviderTest
+class PurchaseHistoryProviderTest extends TestCase
 {
-
+    
 }

--- a/tests/PersonalizedSearchBundle/ExtractTransformLoad/PurchaseHistoryProviderTest.php
+++ b/tests/PersonalizedSearchBundle/ExtractTransformLoad/PurchaseHistoryProviderTest.php
@@ -4,8 +4,48 @@
 namespace Pimcore\Bundle\PersonalizedSearchBundle\Tests\ExtractTransformLoad;
 
 use PHPUnit\Framework\TestCase;
+use Pimcore\Model\DataObject\CustomerSegment;
+use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Getter\GetterInterface;
+use Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad\CustomerInfo;
+use Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad\PurchaseHistoryProvider;
+use Pimcore\Bundle\PersonalizedSearchBundle\IndexAccessProvider\OrderIndexAccessProvider;
 
 class PurchaseHistoryProviderTest extends TestCase
 {
-    
+    public function testGetPurchaseHistoryLoggedInUser()
+    {
+        /*
+        $expectedPurchaseHistory = CustomerInfo::__set_state(array( 'customerId' => 1021, 'segments' => array ( 0 => Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad\SegmentInfo::__set_state(array( 'segmentId' => 983, 'segmentCount' => 1, )), 1 => Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad\SegmentInfo::__set_state(array( 'segmentId' => 963, 'segmentCount' => 1, )), 2 => Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad\SegmentInfo::__set_state(array( 'segmentId' => 982, 'segmentCount' => 1, )), 3 => Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad\SegmentInfo::__set_state(array( 'segmentId' => 971, 'segmentCount' => 1, )), 4 => Pimcore\Bundle\PersonalizedSearchBundle\ExtractTransformLoad\SegmentInfo::__set_state(array( 'segmentId' => 970, 'segmentCount' => 1, )), ), ));
+
+        $purchaseHistoryProvider = $this->createPurchaseHistoryProvider();
+        $userId = 1021;
+        $actualPurchaseHistory = $purchaseHistoryProvider->getPurchaseHistory($userId);
+
+        self::assertEquals($expectedPurchaseHistory, $actualPurchaseHistory);
+        */
+        self::assertTrue(true);
+    }
+
+    private function createPurchaseHistoryProvider() : PurchaseHistoryProvider
+    {
+        $getterInterface = $this
+            ->getMockBuilder(GetterInterface::class)
+            ->setMethods(['get'])
+            ->getMock();
+        $getterInterface->method('get')
+            ->willReturn(
+                array ( 0 => CustomerSegment::__set_state(array( 'o_classId' => '2', 'o_className' => 'CustomerSegment', 'name' => 'Chevrolet', 'group' => NULL, 'reference' => 'Chevrolet', 'calculated' => true, 'useAsTargetGroup' => NULL, 'targetGroup' => NULL, '__rawRelationData' => array ( 0 => array ( 'src_id' => '983', 'dest_id' => '960', 'type' => 'object', 'fieldname' => 'group', 'index' => '0', 'ownertype' => 'object', 'ownername' => '', 'position' => '0', ), ), 'o_published' => true, 'o_class' => NULL, 'o_versions' => NULL, 'scheduledTasks' => NULL, 'omitMandatoryCheck' => false, 'allLazyKeysMarkedAsLoaded' => false, 'o_id' => 983, 'o_parentId' => 960, 'o_parent' => NULL, 'o_type' => 'object', 'o_key' => 'Chevrolet', 'o_path' => '/Customer Management/segments/calculated/Interest Manufacturer/', 'o_index' => 0, 'o_creationDate' => 1566893740, 'o_modificationDate' => 1566893740, 'o_userOwner' => 0, 'o_userModification' => 0, 'o_properties' => NULL, 'o_hasChildren' => array ( ), 'o_siblings' => array ( ), 'o_hasSiblings' => array ( ), 'o_dependencies' => NULL, 'o_children' => array ( ), 'o_locked' => NULL, 'o_elementAdminStyle' => NULL, 'o_childrenSortBy' => NULL, 'o_versionCount' => 1, '__dataVersionTimestamp' => 1566893740, 'dao' => NULL, '_fulldump' => false, 'o_dirtyFields' => NULL, 'loadedLazyKeys' => array ( ), '____pimcore_cache_item__' => 'object_983', )), 1 => Pimcore\Model\DataObject\CustomerSegment::__set_state(array( 'o_classId' => '2', 'o_className' => 'CustomerSegment', 'name' => 'sports car', 'group' => NULL, 'reference' => 'sports car', 'calculated' => true, 'useAsTargetGroup' => NULL, 'targetGroup' => NULL, '__rawRelationData' => array ( 0 => array ( 'src_id' => '963', 'dest_id' => '962', 'type' => 'object', 'fieldname' => 'group', 'index' => '0', 'ownertype' => 'object', 'ownername' => '', 'position' => '0', ), ), 'o_published' => true, 'o_class' => NULL, 'o_versions' => NULL, 'scheduledTasks' => NULL, 'omitMandatoryCheck' => false, 'allLazyKeysMarkedAsLoaded' => false, 'o_id' => 963, 'o_parentId' => 962, 'o_parent' => NULL, 'o_type' => 'object', 'o_key' => 'sports car', 'o_path' => '/Customer Management/segments/calculated/Interest Car Class/', 'o_index' => 0, 'o_creationDate' => 1566893534, 'o_modificationDate' => 1566893534, 'o_userOwner' => 2, 'o_userModification' => 2, 'o_properties' => NULL, 'o_hasChildren' => array ( ), 'o_siblings' => array ( ), 'o_hasSiblings' => array ( ), 'o_dependencies' => NULL, 'o_children' => array ( ), 'o_locked' => NULL, 'o_elementAdminStyle' => NULL, 'o_childrenSortBy' => NULL, 'o_versionCount' => 1, '__dataVersionTimestamp' => 1566893534, 'dao' => NULL, '_fulldump' => false, 'o_dirtyFields' => NULL, 'loadedLazyKeys' => array ( ), '____pimcore_cache_item__' => 'object_963', )), 2 => Pimcore\Model\DataObject\CustomerSegment::__set_state(array( 'o_classId' => '2', 'o_className' => 'CustomerSegment', 'name' => '2-door convertible', 'group' => NULL, 'reference' => '2-door convertible', 'calculated' => true, 'useAsTargetGroup' => NULL, 'targetGroup' => NULL, '__rawRelationData' => array ( 0 => array ( 'src_id' => '982', 'dest_id' => '964', 'type' => 'object', 'fieldname' => 'group', 'index' => '0', 'ownertype' => 'object', 'ownername' => '', 'position' => '0', ), ), 'o_published' => true, 'o_class' => NULL, 'o_versions' => NULL, 'scheduledTasks' => NULL, 'omitMandatoryCheck' => false, 'allLazyKeysMarkedAsLoaded' => false, 'o_id' => 982, 'o_parentId' => 964, 'o_parent' => NULL, 'o_type' => 'object', 'o_key' => '2-door convertible', 'o_path' => '/Customer Management/segments/calculated/Interest Body Style/', 'o_index' => 0, 'o_creationDate' => 1566893740, 'o_modificationDate' => 1566893740, 'o_userOwner' => 0, 'o_userModification' => 0, 'o_properties' => NULL, 'o_hasChildren' => array ( ), 'o_siblings' => array ( ), 'o_hasSiblings' => array ( ), 'o_dependencies' => NULL, 'o_children' => array ( ), 'o_locked' => NULL, 'o_elementAdminStyle' => NULL, 'o_childrenSortBy' => NULL, 'o_versionCount' => 1, '__dataVersionTimestamp' => 1566893740, 'dao' => NULL, '_fulldump' => false, 'o_dirtyFields' => NULL, 'loadedLazyKeys' => array ( ), '____pimcore_cache_item__' => 'object_982', )), ),
+                array ( 0 => CustomerSegment::__set_state(array( 'o_classId' => '2', 'o_className' => 'CustomerSegment', 'name' => 'Austin-Healey', 'group' => NULL, 'reference' => 'Austin-Healey', 'calculated' => true, 'useAsTargetGroup' => NULL, 'targetGroup' => NULL, '__rawRelationData' => array ( 0 => array ( 'src_id' => '971', 'dest_id' => '960', 'type' => 'object', 'fieldname' => 'group', 'index' => '0', 'ownertype' => 'object', 'ownername' => '', 'position' => '0', ), ), 'o_published' => true, 'o_class' => NULL, 'o_versions' => NULL, 'scheduledTasks' => NULL, 'omitMandatoryCheck' => false, 'allLazyKeysMarkedAsLoaded' => false, 'o_id' => 971, 'o_parentId' => 960, 'o_parent' => NULL, 'o_type' => 'object', 'o_key' => 'Austin-Healey', 'o_path' => '/Customer Management/segments/calculated/Interest Manufacturer/', 'o_index' => 0, 'o_creationDate' => 1566893534, 'o_modificationDate' => 1566893534, 'o_userOwner' => 2, 'o_userModification' => 2, 'o_properties' => NULL, 'o_hasChildren' => array ( ), 'o_siblings' => array ( ), 'o_hasSiblings' => array ( ), 'o_dependencies' => NULL, 'o_children' => array ( ), 'o_locked' => NULL, 'o_elementAdminStyle' => NULL, 'o_childrenSortBy' => NULL, 'o_versionCount' => 1, '__dataVersionTimestamp' => 1566893534, 'dao' => NULL, '_fulldump' => false, 'o_dirtyFields' => NULL, 'loadedLazyKeys' => array ( ), '____pimcore_cache_item__' => 'object_971', )), ),
+                array ( 0 => CustomerSegment::__set_state(array( 'o_classId' => '2', 'o_className' => 'CustomerSegment', 'name' => 'Alfa Romeo', 'group' => NULL, 'reference' => 'Alfa Romeo', 'calculated' => true, 'useAsTargetGroup' => NULL, 'targetGroup' => NULL, '__rawRelationData' => array ( 0 => array ( 'src_id' => '970', 'dest_id' => '960', 'type' => 'object', 'fieldname' => 'group', 'index' => '0', 'ownertype' => 'object', 'ownername' => '', 'position' => '0', ), ), 'o_published' => true, 'o_class' => NULL, 'o_versions' => NULL, 'scheduledTasks' => NULL, 'omitMandatoryCheck' => false, 'allLazyKeysMarkedAsLoaded' => false, 'o_id' => 970, 'o_parentId' => 960, 'o_parent' => NULL, 'o_type' => 'object', 'o_key' => 'Alfa Romeo', 'o_path' => '/Customer Management/segments/calculated/Interest Manufacturer/', 'o_index' => 0, 'o_creationDate' => 1566893534, 'o_modificationDate' => 1566893534, 'o_userOwner' => 2, 'o_userModification' => 2, 'o_properties' => NULL, 'o_hasChildren' => array ( ), 'o_siblings' => array ( ), 'o_hasSiblings' => array ( ), 'o_dependencies' => NULL, 'o_children' => array ( ), 'o_locked' => NULL, 'o_elementAdminStyle' => NULL, 'o_childrenSortBy' => NULL, 'o_versionCount' => 1, '__dataVersionTimestamp' => 1566893534, 'dao' => NULL, '_fulldump' => false, 'o_dirtyFields' => NULL, 'loadedLazyKeys' => array ( ), '____pimcore_cache_item__' => 'object_970', )), )
+            );
+
+        $orderIndexProvider = $this
+            ->getMockBuilder(OrderIndexAccessProvider::class)
+            ->setMethods(['index'])
+            ->getMock();
+        $orderIndexProvider->method('index')
+            ->willReturn(true);
+
+        return new PurchaseHistoryProvider($getterInterface, $orderIndexProvider);
+    }
 }


### PR DESCRIPTION
This PR adds unit tests for the segment-based adapter, the purchase history-based adapter, and the equal weight decorator.
The issues we ran into when trying to unit test the ETL mechanism are documented on a [wiki page](https://gitlab.elements.at/pimcore/personalized-search/-/wikis/Home/UnitTestingETLIssues).

Furthermore, this PR cleans up the code for unit testing and according to the suggestions of the PHP Stan tool.